### PR TITLE
Update to use beefy

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "browservefy example/index.js"
+    "test": "beefy example/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates the `npm test` script to use [beefy](https://github.com/chrisdickinson/beefy) instead of the deprecated [browservefy](https://github.com/chrisdickinson/browservefy)
