### PR TITLE
Fixes case when 'options.bindings' is set

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -608,7 +608,7 @@ function createShell(options) {
   
   //Set bindings
   if(options.bindings) {
-    shell.bindings = bindings
+    shell.bindings = options.bindings
   }
   
   //Wait for dom to intiailize


### PR DESCRIPTION
Was throwing an error. Presumably it was a typo.