### PR TITLE
`stickyPointerLock` typos fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-shell",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Ready-to-go game shell",
   "main": "shell.js",
   "directories": {

--- a/shell.js
+++ b/shell.js
@@ -87,7 +87,7 @@ function GameShell() {
   this.tickTime = this._tickRate
   this.frameTime = 10.0
   this.stickyFullscreen = false
-  this.stickyPointLock = false
+  this.stickyPointerLock = false
   
   //Scroll stuff
   this.scroll = [0,0,0]
@@ -604,7 +604,7 @@ function createShell(options) {
   shell._tickRate = options.tickRate || 30
   shell.frameSkip = options.frameSkip || (shell._tickRate+5) * 5
   shell.stickyFullscreen = !!options.stickyFullscreen || !!options.sticky
-  shell.stickyPointerLock = !!options.stickPointerLock || !options.sticky
+  shell.stickyPointerLock = !!options.stickyPointerLock || !!options.sticky
   
   //Set bindings
   if(options.bindings) {


### PR DESCRIPTION
Hi,

This fixes several presumed typos - the `stickyPointerLock` property getting spelled other ways, and getting initialized to `!options.sticky` rather than `!!options.sticky`.

Cheers!